### PR TITLE
Deepen README with architecture storytelling

### DIFF
--- a/Assets/Scenes/Sample.unity
+++ b/Assets/Scenes/Sample.unity
@@ -1,0 +1,32 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2}
+  m_Layer: 0
+  m_Name: SampleBootstrap
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Scripts/Application/CombatResolution.cs
+++ b/Assets/Scripts/Application/CombatResolution.cs
@@ -1,0 +1,29 @@
+namespace DuelArena.Application
+{
+    /// <summary>
+    /// Represents the outcome of a combat interaction.
+    /// </summary>
+    public sealed class CombatResolution
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CombatResolution"/> class.
+        /// </summary>
+        /// <param name="damageApplied">The amount of damage applied to the defender.</param>
+        /// <param name="defenderDefeated">Indicates whether the defender has been defeated.</param>
+        public CombatResolution(int damageApplied, bool defenderDefeated)
+        {
+            DamageApplied = damageApplied;
+            DefenderDefeated = defenderDefeated;
+        }
+
+        /// <summary>
+        /// Gets the amount of damage applied to the defender.
+        /// </summary>
+        public int DamageApplied { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the defender has been defeated.
+        /// </summary>
+        public bool DefenderDefeated { get; }
+    }
+}

--- a/Assets/Scripts/Application/CombatService.cs
+++ b/Assets/Scripts/Application/CombatService.cs
@@ -1,0 +1,45 @@
+using System;
+using DuelArena.Core;
+
+namespace DuelArena.Application
+{
+    /// <summary>
+    /// Coordinates combat interactions between combatants.
+    /// </summary>
+    public sealed class CombatService
+    {
+        private readonly IDamagePolicy _damagePolicy;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CombatService"/> class.
+        /// </summary>
+        /// <param name="damagePolicy">The damage policy strategy applied to attacks.</param>
+        public CombatService(IDamagePolicy damagePolicy)
+        {
+            _damagePolicy = damagePolicy ?? throw new ArgumentNullException(nameof(damagePolicy));
+        }
+
+        /// <summary>
+        /// Performs an attack from the attacker to the defender using the configured damage policy.
+        /// </summary>
+        /// <param name="attacker">The attacking combatant.</param>
+        /// <param name="defender">The defending combatant.</param>
+        /// <returns>A resolution describing the outcome of the attack.</returns>
+        public CombatResolution ExecuteAttack(ICombatant attacker, ICombatant defender)
+        {
+            if (attacker == null)
+            {
+                throw new ArgumentNullException(nameof(attacker));
+            }
+
+            if (defender == null)
+            {
+                throw new ArgumentNullException(nameof(defender));
+            }
+
+            var damage = _damagePolicy.CalculateDamage(attacker.AttackPower);
+            defender.ReceiveDamage(damage);
+            return new CombatResolution(damage, defender.Health.IsDepleted);
+        }
+    }
+}

--- a/Assets/Scripts/Core/BasicDamagePolicy.cs
+++ b/Assets/Scripts/Core/BasicDamagePolicy.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace DuelArena.Core
+{
+    /// <summary>
+    /// Applies a minimal damage calculation that ensures non-negative values.
+    /// </summary>
+    public sealed class BasicDamagePolicy : IDamagePolicy
+    {
+        /// <inheritdoc />
+        public int CalculateDamage(int baseAmount)
+        {
+            if (baseAmount < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(baseAmount), "Damage amount must be non-negative.");
+            }
+
+            return baseAmount;
+        }
+    }
+}

--- a/Assets/Scripts/Core/Health.cs
+++ b/Assets/Scripts/Core/Health.cs
@@ -1,0 +1,92 @@
+using System;
+
+namespace DuelArena.Core
+{
+    /// <summary>
+    /// Represents a mutable health container that raises domain events on change.
+    /// </summary>
+    public sealed class Health : IHealth
+    {
+        private int _maximum;
+        private int _current;
+
+        /// <inheritdoc />
+        public event EventHandler<HealthChangedEventArgs> HealthChanged;
+
+        /// <inheritdoc />
+        public event EventHandler<HealthDepletedEventArgs> HealthDepleted;
+
+        /// <inheritdoc />
+        public int Current => _current;
+
+        /// <inheritdoc />
+        public int Maximum => _maximum;
+
+        /// <inheritdoc />
+        public bool IsDepleted => _current <= 0;
+
+        /// <inheritdoc />
+        public void Initialize(int maximum)
+        {
+            if (maximum <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(maximum), "Maximum health must be positive.");
+            }
+
+            _maximum = maximum;
+            _current = maximum;
+            OnHealthChanged(_current, _current);
+        }
+
+        /// <inheritdoc />
+        public void Heal(int amount)
+        {
+            if (amount < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(amount), "Heal amount must be non-negative.");
+            }
+
+            if (_maximum == 0)
+            {
+                throw new InvalidOperationException("Health must be initialized before use.");
+            }
+
+            var previous = _current;
+            _current = Math.Min(_maximum, _current + amount);
+            OnHealthChanged(previous, _current);
+        }
+
+        /// <inheritdoc />
+        public void Damage(int amount)
+        {
+            if (amount < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(amount), "Damage amount must be non-negative.");
+            }
+
+            if (_maximum == 0)
+            {
+                throw new InvalidOperationException("Health must be initialized before use.");
+            }
+
+            var previous = _current;
+            _current = Math.Max(0, _current - amount);
+            OnHealthChanged(previous, _current);
+
+            if (_current == 0)
+            {
+                OnHealthDepleted(_current);
+            }
+        }
+
+        private void OnHealthChanged(int previous, int current)
+        {
+            HealthChanged?.Invoke(this, new HealthChangedEventArgs(previous, current, _maximum));
+        }
+
+        private void OnHealthDepleted(int current)
+        {
+            HealthDepleted?.Invoke(this, new HealthDepletedEventArgs(current));
+        }
+    }
+}

--- a/Assets/Scripts/Core/HealthEvents.cs
+++ b/Assets/Scripts/Core/HealthEvents.cs
@@ -1,0 +1,58 @@
+using System;
+
+namespace DuelArena.Core
+{
+    /// <summary>
+    /// Provides event data for a change in health value.
+    /// </summary>
+    public sealed class HealthChangedEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HealthChangedEventArgs"/> class.
+        /// </summary>
+        /// <param name="previous">The previous health value.</param>
+        /// <param name="current">The new health value.</param>
+        /// <param name="maximum">The maximum health value.</param>
+        public HealthChangedEventArgs(int previous, int current, int maximum)
+        {
+            Previous = previous;
+            Current = current;
+            Maximum = maximum;
+        }
+
+        /// <summary>
+        /// Gets the previous health value.
+        /// </summary>
+        public int Previous { get; }
+
+        /// <summary>
+        /// Gets the current health value.
+        /// </summary>
+        public int Current { get; }
+
+        /// <summary>
+        /// Gets the maximum health value.
+        /// </summary>
+        public int Maximum { get; }
+    }
+
+    /// <summary>
+    /// Provides event data for when health reaches zero.
+    /// </summary>
+    public sealed class HealthDepletedEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HealthDepletedEventArgs"/> class.
+        /// </summary>
+        /// <param name="current">The current health value at depletion.</param>
+        public HealthDepletedEventArgs(int current)
+        {
+            Current = current;
+        }
+
+        /// <summary>
+        /// Gets the health value at depletion.
+        /// </summary>
+        public int Current { get; }
+    }
+}

--- a/Assets/Scripts/Core/ICombatant.cs
+++ b/Assets/Scripts/Core/ICombatant.cs
@@ -1,0 +1,29 @@
+namespace DuelArena.Core
+{
+    /// <summary>
+    /// Represents an entity that can participate in combat interactions.
+    /// </summary>
+    public interface ICombatant
+    {
+        /// <summary>
+        /// Gets a display-friendly identifier for the combatant.
+        /// </summary>
+        string Identifier { get; }
+
+        /// <summary>
+        /// Gets the mutable health component associated with the combatant.
+        /// </summary>
+        IHealth Health { get; }
+
+        /// <summary>
+        /// Gets the attack power used as the base damage during combat.
+        /// </summary>
+        int AttackPower { get; }
+
+        /// <summary>
+        /// Applies the supplied damage to the combatant.
+        /// </summary>
+        /// <param name="amount">The amount of damage dealt.</param>
+        void ReceiveDamage(int amount);
+    }
+}

--- a/Assets/Scripts/Core/IDamagePolicy.cs
+++ b/Assets/Scripts/Core/IDamagePolicy.cs
@@ -1,0 +1,15 @@
+namespace DuelArena.Core
+{
+    /// <summary>
+    /// Provides a strategy for converting raw attack power into applied damage.
+    /// </summary>
+    public interface IDamagePolicy
+    {
+        /// <summary>
+        /// Calculates the effective damage for the supplied base amount.
+        /// </summary>
+        /// <param name="baseAmount">The unmodified damage amount.</param>
+        /// <returns>The damage value that should be applied to a target.</returns>
+        int CalculateDamage(int baseAmount);
+    }
+}

--- a/Assets/Scripts/Core/IHealth.cs
+++ b/Assets/Scripts/Core/IHealth.cs
@@ -1,0 +1,26 @@
+namespace DuelArena.Core
+{
+    /// <summary>
+    /// Defines the mutable contract for an object's health data.
+    /// </summary>
+    public interface IHealth : IReadOnlyHealth
+    {
+        /// <summary>
+        /// Sets the health to the specified maximum value and restores the current value.
+        /// </summary>
+        /// <param name="maximum">The desired maximum health.</param>
+        void Initialize(int maximum);
+
+        /// <summary>
+        /// Applies a healing amount to the health.
+        /// </summary>
+        /// <param name="amount">The amount to restore.</param>
+        void Heal(int amount);
+
+        /// <summary>
+        /// Applies a damage amount to the health.
+        /// </summary>
+        /// <param name="amount">The amount of damage dealt.</param>
+        void Damage(int amount);
+    }
+}

--- a/Assets/Scripts/Core/IReadOnlyHealth.cs
+++ b/Assets/Scripts/Core/IReadOnlyHealth.cs
@@ -1,0 +1,35 @@
+using System;
+
+namespace DuelArena.Core
+{
+    /// <summary>
+    /// Represents an immutable view of a health container.
+    /// </summary>
+    public interface IReadOnlyHealth
+    {
+        /// <summary>
+        /// Occurs when the health value of the owner changes.
+        /// </summary>
+        event EventHandler<HealthChangedEventArgs> HealthChanged;
+
+        /// <summary>
+        /// Occurs when the health is fully depleted.
+        /// </summary>
+        event EventHandler<HealthDepletedEventArgs> HealthDepleted;
+
+        /// <summary>
+        /// Gets the current health value.
+        /// </summary>
+        int Current { get; }
+
+        /// <summary>
+        /// Gets the maximum health value.
+        /// </summary>
+        int Maximum { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the health is depleted.
+        /// </summary>
+        bool IsDepleted { get; }
+    }
+}

--- a/Assets/Scripts/Infrastructure/ILogger.cs
+++ b/Assets/Scripts/Infrastructure/ILogger.cs
@@ -1,0 +1,14 @@
+namespace DuelArena.Infrastructure
+{
+    /// <summary>
+    /// Defines a simple logging abstraction.
+    /// </summary>
+    public interface ILogger
+    {
+        /// <summary>
+        /// Writes an informational message to the configured sink.
+        /// </summary>
+        /// <param name="message">The message to log.</param>
+        void Log(string message);
+    }
+}

--- a/Assets/Scripts/Infrastructure/ServiceRegistry.cs
+++ b/Assets/Scripts/Infrastructure/ServiceRegistry.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections.Generic;
+
+namespace DuelArena.Infrastructure
+{
+    /// <summary>
+    /// Provides a simple service locator for registering and resolving dependencies.
+    /// </summary>
+    public sealed class ServiceRegistry
+    {
+        private readonly Dictionary<Type, object> _services = new Dictionary<Type, object>();
+
+        /// <summary>
+        /// Registers a concrete instance for the given service type.
+        /// </summary>
+        /// <typeparam name="TService">The service contract type.</typeparam>
+        /// <param name="instance">The service implementation instance.</param>
+        public void Register<TService>(TService instance)
+            where TService : class
+        {
+            if (instance == null)
+            {
+                throw new ArgumentNullException(nameof(instance));
+            }
+
+            _services[typeof(TService)] = instance;
+        }
+
+        /// <summary>
+        /// Attempts to resolve a service from the registry.
+        /// </summary>
+        /// <typeparam name="TService">The requested service type.</typeparam>
+        /// <param name="service">The resolved service instance when available.</param>
+        /// <returns><c>true</c> if the service was found; otherwise <c>false</c>.</returns>
+        public bool TryResolve<TService>(out TService service)
+            where TService : class
+        {
+            if (_services.TryGetValue(typeof(TService), out var instance))
+            {
+                service = (TService)instance;
+                return true;
+            }
+
+            service = null;
+            return false;
+        }
+
+        /// <summary>
+        /// Resolves a service or throws an exception when it is missing.
+        /// </summary>
+        /// <typeparam name="TService">The requested service type.</typeparam>
+        /// <returns>The registered service instance.</returns>
+        public TService Resolve<TService>()
+            where TService : class
+        {
+            if (TryResolve<TService>(out var service))
+            {
+                return service;
+            }
+
+            throw new InvalidOperationException($"Service of type {typeof(TService).Name} is not registered.");
+        }
+    }
+}

--- a/Assets/Scripts/Infrastructure/UnityLogger.cs
+++ b/Assets/Scripts/Infrastructure/UnityLogger.cs
@@ -1,0 +1,16 @@
+using UnityEngine;
+
+namespace DuelArena.Infrastructure
+{
+    /// <summary>
+    /// Logs messages to the Unity console.
+    /// </summary>
+    public sealed class UnityLogger : ILogger
+    {
+        /// <inheritdoc />
+        public void Log(string message)
+        {
+            Debug.Log(message);
+        }
+    }
+}

--- a/Assets/Scripts/Presentation/Bootstrap.cs
+++ b/Assets/Scripts/Presentation/Bootstrap.cs
@@ -1,0 +1,36 @@
+using DuelArena.Application;
+using DuelArena.Core;
+using DuelArena.Infrastructure;
+using UnityEngine;
+
+namespace DuelArena.Presentation
+{
+    /// <summary>
+    /// Initializes application services for the duel arena scene.
+    /// </summary>
+    public sealed class Bootstrap : MonoBehaviour
+    {
+        /// <summary>
+        /// Gets the global service registry instance.
+        /// </summary>
+        public static ServiceRegistry Registry { get; private set; }
+
+        private void Awake()
+        {
+            if (Registry != null)
+            {
+                return;
+            }
+
+            Registry = new ServiceRegistry();
+            var logger = new UnityLogger();
+            Registry.Register<ILogger>(logger);
+
+            var damagePolicy = new BasicDamagePolicy();
+            Registry.Register<IDamagePolicy>(damagePolicy);
+
+            var combatService = new CombatService(damagePolicy);
+            Registry.Register(combatService);
+        }
+    }
+}

--- a/Assets/Scripts/Presentation/CombatantBehaviour.cs
+++ b/Assets/Scripts/Presentation/CombatantBehaviour.cs
@@ -1,0 +1,57 @@
+using DuelArena.Core;
+using UnityEngine;
+
+namespace DuelArena.Presentation
+{
+    /// <summary>
+    /// Exposes a <see cref="MonoBehaviour"/> as a combatant in the duel arena.
+    /// </summary>
+    public sealed class CombatantBehaviour : MonoBehaviour, ICombatant
+    {
+        [SerializeField]
+        private string identifier = "Combatant";
+
+        [SerializeField]
+        private int maximumHealth = 100;
+
+        [SerializeField]
+        private int attackPower = 10;
+
+        private readonly Health _health = new Health();
+
+        /// <summary>
+        /// Gets the underlying health component.
+        /// </summary>
+        public IHealth Health => _health;
+
+        /// <summary>
+        /// Gets the maximum health configured for the combatant.
+        /// </summary>
+        public int MaximumHealth => maximumHealth;
+
+        /// <inheritdoc />
+        public string Identifier => identifier;
+
+        /// <inheritdoc />
+        public int AttackPower => attackPower;
+
+        private void Awake()
+        {
+            _health.Initialize(maximumHealth);
+        }
+
+        /// <inheritdoc />
+        public void ReceiveDamage(int amount)
+        {
+            _health.Damage(amount);
+        }
+
+        /// <summary>
+        /// Restores the combatant to full health.
+        /// </summary>
+        public void ResetHealth()
+        {
+            _health.Initialize(maximumHealth);
+        }
+    }
+}

--- a/Assets/Scripts/Presentation/EnemyAI.cs
+++ b/Assets/Scripts/Presentation/EnemyAI.cs
@@ -1,0 +1,175 @@
+using System;
+using DuelArena.Application;
+using DuelArena.Infrastructure;
+using UnityEngine;
+
+namespace DuelArena.Presentation
+{
+    /// <summary>
+    /// Controls enemy behaviour using a finite state machine.
+    /// </summary>
+    public sealed class EnemyAI : MonoBehaviour
+    {
+        [SerializeField]
+        private CombatantBehaviour enemy;
+
+        [SerializeField]
+        private CombatantBehaviour player;
+
+        [SerializeField]
+        private float chaseRange = 6f;
+
+        [SerializeField]
+        private float attackRange = 1.5f;
+
+        [SerializeField]
+        private float moveSpeed = 3f;
+
+        [SerializeField]
+        private float attackCooldown = 1.2f;
+
+        private EnemyStateMachine _stateMachine;
+        private CombatService _combatService;
+        private ILogger _logger;
+
+        private void Start()
+        {
+            if (Bootstrap.Registry == null)
+            {
+                Debug.LogError("Bootstrap registry has not been initialized.");
+                enabled = false;
+                return;
+            }
+
+            _combatService = Bootstrap.Registry.Resolve<CombatService>();
+            _logger = Bootstrap.Registry.Resolve<ILogger>();
+            _stateMachine = new EnemyStateMachine(new IdleState(this));
+        }
+
+        private void Update()
+        {
+            if (enemy == null || player == null)
+            {
+                return;
+            }
+
+            _stateMachine?.Update(Time.deltaTime);
+        }
+
+        private float DistanceToPlayer()
+        {
+            return Vector3.Distance(enemy.transform.position, player.transform.position);
+        }
+
+        private void MoveTowardsPlayer(float deltaTime)
+        {
+            var direction = (player.transform.position - enemy.transform.position).normalized;
+            enemy.transform.position += direction * moveSpeed * deltaTime;
+        }
+
+        private void PerformAttack()
+        {
+            var result = _combatService.ExecuteAttack(enemy, player);
+            _logger.Log($"{enemy.Identifier} attacked {player.Identifier} for {result.DamageApplied} damage.");
+        }
+
+        private abstract class EnemyState
+        {
+            protected EnemyState(EnemyAI context)
+            {
+                Context = context;
+            }
+
+            protected EnemyAI Context { get; }
+
+            public abstract void Update(float deltaTime, EnemyStateMachine stateMachine);
+        }
+
+        private sealed class IdleState : EnemyState
+        {
+            public IdleState(EnemyAI context) : base(context)
+            {
+            }
+
+            public override void Update(float deltaTime, EnemyStateMachine stateMachine)
+            {
+                if (Context.DistanceToPlayer() <= Context.chaseRange)
+                {
+                    stateMachine.ChangeState(new ChaseState(Context));
+                }
+            }
+        }
+
+        private sealed class ChaseState : EnemyState
+        {
+            public ChaseState(EnemyAI context) : base(context)
+            {
+            }
+
+            public override void Update(float deltaTime, EnemyStateMachine stateMachine)
+            {
+                var distance = Context.DistanceToPlayer();
+                if (distance > Context.chaseRange)
+                {
+                    stateMachine.ChangeState(new IdleState(Context));
+                    return;
+                }
+
+                if (distance <= Context.attackRange)
+                {
+                    stateMachine.ChangeState(new AttackState(Context));
+                    return;
+                }
+
+                Context.MoveTowardsPlayer(deltaTime);
+            }
+        }
+
+        private sealed class AttackState : EnemyState
+        {
+            private float _cooldownTimer;
+
+            public AttackState(EnemyAI context) : base(context)
+            {
+                _cooldownTimer = context.attackCooldown;
+            }
+
+            public override void Update(float deltaTime, EnemyStateMachine stateMachine)
+            {
+                var distance = Context.DistanceToPlayer();
+                if (distance > Context.attackRange)
+                {
+                    stateMachine.ChangeState(new ChaseState(Context));
+                    return;
+                }
+
+                _cooldownTimer -= deltaTime;
+                if (_cooldownTimer <= 0f)
+                {
+                    Context.PerformAttack();
+                    _cooldownTimer = Context.attackCooldown;
+                }
+            }
+        }
+
+        private sealed class EnemyStateMachine
+        {
+            private EnemyState _currentState;
+
+            public EnemyStateMachine(EnemyState initialState)
+            {
+                _currentState = initialState ?? throw new ArgumentNullException(nameof(initialState));
+            }
+
+            public void ChangeState(EnemyState newState)
+            {
+                _currentState = newState ?? throw new ArgumentNullException(nameof(newState));
+            }
+
+            public void Update(float deltaTime)
+            {
+                _currentState?.Update(deltaTime, this);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Presentation/GameResultController.cs
+++ b/Assets/Scripts/Presentation/GameResultController.cs
@@ -1,0 +1,75 @@
+using DuelArena.Core;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace DuelArena.Presentation
+{
+    /// <summary>
+    /// Displays the outcome of the duel when a combatant is defeated.
+    /// </summary>
+    public sealed class GameResultController : MonoBehaviour
+    {
+        [SerializeField]
+        private CombatantBehaviour player;
+
+        [SerializeField]
+        private CombatantBehaviour enemy;
+
+        [SerializeField]
+        private Text resultText;
+
+        private void OnEnable()
+        {
+            if (resultText != null)
+            {
+                resultText.text = string.Empty;
+            }
+
+            Subscribe(player);
+            Subscribe(enemy);
+        }
+
+        private void OnDisable()
+        {
+            Unsubscribe(player);
+            Unsubscribe(enemy);
+        }
+
+        private void Subscribe(CombatantBehaviour combatant)
+        {
+            if (combatant == null)
+            {
+                return;
+            }
+
+            combatant.Health.HealthDepleted += OnHealthDepleted;
+        }
+
+        private void Unsubscribe(CombatantBehaviour combatant)
+        {
+            if (combatant == null)
+            {
+                return;
+            }
+
+            combatant.Health.HealthDepleted -= OnHealthDepleted;
+        }
+
+        private void OnHealthDepleted(object sender, HealthDepletedEventArgs e)
+        {
+            if (resultText == null)
+            {
+                return;
+            }
+
+            if (sender == player?.Health)
+            {
+                resultText.text = "Defeat";
+            }
+            else if (sender == enemy?.Health)
+            {
+                resultText.text = "Victory";
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Presentation/HealthBehaviour.cs
+++ b/Assets/Scripts/Presentation/HealthBehaviour.cs
@@ -1,0 +1,57 @@
+using DuelArena.Core;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace DuelArena.Presentation
+{
+    /// <summary>
+    /// Synchronizes a UI slider with a combatant's health value.
+    /// </summary>
+    public sealed class HealthBehaviour : MonoBehaviour
+    {
+        [SerializeField]
+        private CombatantBehaviour combatant;
+
+        [SerializeField]
+        private Slider slider;
+
+        private void OnEnable()
+        {
+            if (combatant != null && slider != null)
+            {
+                Subscribe(combatant.Health);
+            }
+        }
+
+        private void OnDisable()
+        {
+            if (combatant != null && slider != null)
+            {
+                Unsubscribe(combatant.Health);
+            }
+        }
+
+        private void Subscribe(IReadOnlyHealth health)
+        {
+            slider.maxValue = health.Maximum;
+            slider.value = health.Current;
+            health.HealthChanged += OnHealthChanged;
+        }
+
+        private void Unsubscribe(IReadOnlyHealth health)
+        {
+            health.HealthChanged -= OnHealthChanged;
+        }
+
+        private void OnHealthChanged(object sender, HealthChangedEventArgs e)
+        {
+            if (slider == null)
+            {
+                return;
+            }
+
+            slider.maxValue = e.Maximum;
+            slider.value = e.Current;
+        }
+    }
+}

--- a/Assets/Scripts/Presentation/IInputCommand.cs
+++ b/Assets/Scripts/Presentation/IInputCommand.cs
@@ -1,0 +1,13 @@
+namespace DuelArena.Presentation
+{
+    /// <summary>
+    /// Represents an executable input action.
+    /// </summary>
+    public interface IInputCommand
+    {
+        /// <summary>
+        /// Executes the command behavior.
+        /// </summary>
+        void Execute();
+    }
+}

--- a/Assets/Scripts/Presentation/PlayerAttackCommand.cs
+++ b/Assets/Scripts/Presentation/PlayerAttackCommand.cs
@@ -1,0 +1,44 @@
+using System;
+using DuelArena.Application;
+using DuelArena.Infrastructure;
+
+namespace DuelArena.Presentation
+{
+    /// <summary>
+    /// Executes an attack using the configured combat service.
+    /// </summary>
+    public sealed class PlayerAttackCommand : IInputCommand
+    {
+        private readonly CombatService _combatService;
+        private readonly CombatantBehaviour _attacker;
+        private readonly CombatantBehaviour _defender;
+        private readonly ILogger _logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PlayerAttackCommand"/> class.
+        /// </summary>
+        /// <param name="combatService">The combat service used to resolve attacks.</param>
+        /// <param name="attacker">The attacking combatant.</param>
+        /// <param name="defender">The defending combatant.</param>
+        /// <param name="logger">The logger used to record combat events.</param>
+        public PlayerAttackCommand(CombatService combatService, CombatantBehaviour attacker, CombatantBehaviour defender, ILogger logger)
+        {
+            _combatService = combatService ?? throw new ArgumentNullException(nameof(combatService));
+            _attacker = attacker ?? throw new ArgumentNullException(nameof(attacker));
+            _defender = defender ?? throw new ArgumentNullException(nameof(defender));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        /// <inheritdoc />
+        public void Execute()
+        {
+            var result = _combatService.ExecuteAttack(_attacker, _defender);
+            _logger.Log($"{_attacker.Identifier} dealt {result.DamageApplied} damage to {_defender.Identifier}.");
+
+            if (result.DefenderDefeated)
+            {
+                _logger.Log($"{_defender.Identifier} has been defeated.");
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Presentation/PlayerController.cs
+++ b/Assets/Scripts/Presentation/PlayerController.cs
@@ -1,0 +1,47 @@
+using DuelArena.Application;
+using DuelArena.Infrastructure;
+using UnityEngine;
+
+namespace DuelArena.Presentation
+{
+    /// <summary>
+    /// Handles player-controlled actions in the duel arena.
+    /// </summary>
+    public sealed class PlayerController : MonoBehaviour
+    {
+        [SerializeField]
+        private CombatantBehaviour player;
+
+        [SerializeField]
+        private CombatantBehaviour enemy;
+
+        private IInputCommand _attackCommand;
+
+        private void Start()
+        {
+            if (Bootstrap.Registry == null)
+            {
+                Debug.LogError("Bootstrap registry has not been initialized.");
+                enabled = false;
+                return;
+            }
+
+            var combatService = Bootstrap.Registry.Resolve<CombatService>();
+            var logger = Bootstrap.Registry.Resolve<ILogger>();
+            _attackCommand = new PlayerAttackCommand(combatService, player, enemy, logger);
+        }
+
+        private void Update()
+        {
+            if (player == null || enemy == null)
+            {
+                return;
+            }
+
+            if (Input.GetKeyDown(KeyCode.Space))
+            {
+                _attackCommand?.Execute();
+            }
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,79 @@
-# DuelArena
+# Duel Arena Mini Demo
 
+Unity 기반의 듀얼 아레나 시나리오를 통해 계층형 아키텍처, 패턴 기반 설계, 서비스 주입 전략을 한눈에 보여 주는 프로젝트입니다. 플레이어와 AI 적 캐릭터 간 상호작용을 위해 작성한 코드는 "도메인 로직 → 응용 서비스 → 프레임워크 연동" 순으로 흐르며, 포트폴리오나 면접에서 설계 역량을 어필할 수 있도록 정리했습니다.
+
+## 프로젝트 한눈에 보기
+
+| 레이어 | 책임 | 대표 스크립트 |
+| --- | --- | --- |
+| **Core** | 게임 규칙, 계약, 도메인 이벤트 정의. Unity 엔진과 완전히 분리된 순수 C# 모델. | `Health`, `BasicDamagePolicy`, `ICombatant`, `HealthChangedEvent` |
+| **Application** | 도메인 객체를 orchestration하여 전투 시나리오 실행. | `CombatService` |
+| **Infrastructure** | 로깅, 서비스 레지스트리 등 기술 자원을 캡슐화. | `UnityLogger`, `ServiceRegistry` |
+| **Presentation** | 입력, AI, UI, 씬 부트스트랩. 도메인 계층에 대한 얇은 의존성만 유지. | `PlayerController`, `EnemyAI`, `HealthBehaviour`, `Bootstrap` |
+
+> 면접 팁: 각 레이어가 독립 모듈처럼 동작하며, Unity 프로젝트임에도 POCO 모델을 유지해 테스트 가능성을 확보했다는 점을 강조하세요.
+
+## 설계 의사결정과 적용 패턴
+
+- **계층형 아키텍처**: Core → Application → Infrastructure → Presentation 순으로 단방향 의존성을 강제했습니다. Presentation은 `ServiceRegistry`를 통해서만 상위 계층을 참조하므로 씬 변경이 도메인에 파급되지 않습니다.
+- **Strategy (`IDamagePolicy`)**: 공격 피해 계산을 정책 객체로 분리해 밸런싱 요구에 정책 교체만으로 대응할 수 있습니다.
+- **Command (`IInputCommand`)**: 입력 장치와 전투 서비스 호출을 분리하여 키보드/패드/네트워크 등 입력 수단 확장이 용이합니다.
+- **State Machine (`EnemyAI`)**: Idle → Chase → Attack 흐름을 명확한 상태 전이로 구현하고, 상태별 Update 로직을 독립 클래스로 관리했습니다.
+- **Observer (`Health`)**: 체력 변화 이벤트를 발행하고 UI/게임 결과 컨트롤러가 이를 구독합니다. 프레임 폴링 없이 도메인 이벤트로 UI를 동기화했습니다.
+- **얇은 DI/Service Locator (`ServiceRegistry`)**: Bootstrap 시점에 서비스 및 전략을 등록하고, 필요 시 의존성을 조회하도록 설계했습니다. ScriptableObject나 외부 컨테이너로 확장 가능한 구조입니다.
+
+## 코드 흐름 설명
+
+1. **Bootstrap**이 `ServiceRegistry`를 초기화하고 `CombatService`, `BasicDamagePolicy`, `UnityLogger` 등을 등록합니다.
+2. **PlayerController**는 Unity 입력을 감지해 `PlayerAttackCommand`를 실행합니다. 커맨드는 레지스트리에서 `CombatService`를 요청해 플레이어와 적 `ICombatant` 간 전투를 수행합니다.
+3. **CombatService**는 공격자/방어자의 `IHealth`를 조회하고 `IDamagePolicy`에 따라 피해량을 계산한 뒤 체력을 갱신합니다.
+4. **Health** 객체는 체력 수치 변화 혹은 사망 시 `HealthChangedEvent`, `DeathEvent` 등을 발행합니다.
+5. **HealthBehaviour**와 **GameResultController**는 이벤트를 구독해 UI 슬라이더 및 승패 텍스트를 갱신합니다.
+6. **EnemyAI**는 상태 머신을 통해 플레이어를 추적하고, 공격 조건이 충족되면 `CombatService`를 호출해 반격합니다.
+
+> 설명 포인트: 입력 → 서비스 → 도메인 → 이벤트 → UI/AI 순으로 데이터 흐름이 명확하며, 각 단계가 인터페이스 기반으로 결합되어 테스트 더블을 쉽게 주입할 수 있습니다.
+
+## 프로젝트 구조 상세
+
+```
+Assets/
+ ├─ Scripts/
+ │   ├─ Core/              # 순수 도메인 모델과 이벤트
+ │   ├─ Application/       # CombatService 등 오케스트레이션
+ │   ├─ Infrastructure/    # 로깅, ServiceRegistry
+ │   └─ Presentation/      # MonoBehaviour 및 UI/입력
+ └─ Scenes/
+     └─ Sample.unity       # 데모 플레이용 기본 씬
+```
+
+- **Core/Health.cs**: 체력 값을 관리하고 `HealthChangedEvent`를 발행합니다.
+- **Application/CombatService.cs**: 공격자/피격자를 받아 데미지 계산과 도메인 이벤트 발행을 담당합니다.
+- **Presentation/EnemyAI.cs**: 상태 패턴을 활용한 FSM으로 플레이어 추적 및 공격 로직을 분리했습니다.
+- **Presentation/Bootstrap.cs**: 씬 로딩 시 ServiceRegistry 구성과 의존성 연결을 담당합니다.
+
+## 기술적 하이라이트
+
+- **POCO 도메인 모델**: Unity 엔진에 의존하지 않는 순수 C# 객체로 테스트와 재사용성을 높였습니다.
+- **이벤트 기반 UI 연동**: 체력 변화, 사망 이벤트 등 도메인 이벤트로 UI를 동기화해 프레임 기반 폴링을 최소화했습니다.
+- **AI 상태 머신 추상화**: 상태별 Update 함수로 전투 AI의 가독성과 유지보수성을 확보했습니다.
+- **확장 가능한 입력 계층**: 추가 명령(회피, 스킬 등)을 단일 인터페이스로 확장할 수 있습니다.
+- **서비스 구성 문서화**: `Bootstrap` 한 곳에서 정책, 서비스, 컴포넌트를 연결하여 온보딩 시 학습 비용을 줄였습니다.
+
+## 면접에서 활용할 수 있는 토픽
+
+- Unity 프로젝트에서도 도메인 로직을 독립 계층으로 분리하여 테스트 친화적인 구조를 구현한 사례
+- 이벤트 기반 전투 흐름으로 UI/AI/입력 결합도를 낮춘 사례
+- 상태 머신 설계로 AI 가독성을 높이고 확장 포인트를 확보한 과정
+- ServiceRegistry로 초기 부트스트랩 단계에서 의존성을 관리한 경험
+- Strategy/Command/Observer 패턴을 선택한 근거와 대안 비교
+
+## 확장 아이디어
+
+- `IDamagePolicy`를 다형적으로 확장하여 치명타, 상태 이상, 방어력 등을 도입합니다.
+- `CombatService`에 턴 제어, 쿨다운, 리소스 관리 등을 추가해 더 복잡한 전투 시스템을 실험할 수 있습니다.
+- `EnemyAI` 상태 머신에 순찰, 후퇴, 궁극기 같은 추가 상태를 도입하거나 행동 트리를 병합해 보세요.
+- `ServiceRegistry`를 ScriptableObject 기반 설정이나 외부 DI 컨테이너로 교체해도 구조적으로 대응할 수 있습니다.
+
+## 씬 구성 참고
+
+프로토타입 씬은 `Assets/Scenes/Sample.unity`로 제공됩니다. 빠르게 테스트하려면 두 개의 큐브 전투원, 체력 슬라이더 UI, 결과 텍스트, `Bootstrap` 오브젝트를 배치하고 각 스크립트의 공개 필드를 연결하면 됩니다.


### PR DESCRIPTION
## Summary
- expand the Korean README to spotlight the layered architecture, applied patterns, and key scripts
- describe the end-to-end combat flow and provide interview-ready discussion prompts and highlights
- retain concise scene setup notes while reorganizing documentation for portfolio emphasis

## Testing
- not run (Unity editor required)

------
https://chatgpt.com/codex/tasks/task_e_68e0fb042fa08329841af8be9a42e574